### PR TITLE
Bug fix for MPU9250_SelfTest()

### DIFF
--- a/MPU9250/Design01.cydsn/MPU9250.c
+++ b/MPU9250/Design01.cydsn/MPU9250.c
@@ -175,7 +175,7 @@ void MPU9250_ReadAccGyroRaw(uint8_t* data) {
     MPU9250_I2C_ReadMulti(MPU9250_I2C_ADDRESS, MPU9250_GYRO_XOUT_H_REG, data + 6, 6);
 }
 
-void MPU9250_ReadMag(uint16_t* mag) {
+void MPU9250_ReadMag(int16_t* mag) {
     
     uint8_t temp[6];
     // Get RAW data
@@ -192,7 +192,7 @@ void MPU9250_ReadMagRaw(uint8_t* mag) {
     MPU9250_I2C_ReadMulti(AK8963_I2C_ADDRESS, MPU9250_MAG_XOUT_H_REG, mag, 6);
 }
 
-void MPU9250_ReadSelfTestGyro(uint8_t* self_test_gyro) {
+void MPU9250_ReadSelfTestGyro(int16_t* self_test_gyro) {
     uint8_t temp[6];
     
     MPU9250_I2C_ReadMulti(MPU9250_I2C_ADDRESS, MPU9250_SELF_TEST_X_GYRO_REG, temp, 6);
@@ -201,7 +201,7 @@ void MPU9250_ReadSelfTestGyro(uint8_t* self_test_gyro) {
     self_test_gyro[2] = ( temp[2] << 8) | ( temp[5] & 0xFF);
 }
 
-void MPU9250_ReadSelfTestAcc(uint8_t* self_test_acc) {
+void MPU9250_ReadSelfTestAcc(int16_t* self_test_acc) {
     uint8_t temp[6];
     
     MPU9250_I2C_ReadMulti(MPU9250_I2C_ADDRESS, MPU9250_SELF_TEST_X_ACCEL_REG, temp, 6);
@@ -327,8 +327,8 @@ void MPU9250_SelfTest(float* deviation) {
     ST_Response[5] = ST_Gyro[2] - Gyro[2];
     
     // Get values stored in the device for self test
-    uint8_t ST_AccStored[3];
-    uint8_t ST_GyroStored[3];
+    int16_t ST_AccStored[3];
+    int16_t ST_GyroStored[3];
     
     MPU9250_ReadSelfTestAcc(ST_AccStored);
     MPU9250_ReadSelfTestGyro(ST_GyroStored);

--- a/MPU9250/Design01.cydsn/MPU9250.h
+++ b/MPU9250/Design01.cydsn/MPU9250.h
@@ -170,7 +170,7 @@
     * @param[out] mag: magnetometer raw values (xH, xL, yH, yL, zH, zL).
     *
     */
-    void MPU9250_ReadMag(uint16_t* mag);
+    void MPU9250_ReadMag(int16_t* mag);
     
      /**
     * @brief Read magnetometer raw values.
@@ -217,8 +217,8 @@
     void MPU9250_ReadMag(void);
     */
     
-    void MPU9250_ReadSelfTestGyro(uint8_t* self_test_gyro);
-    void MPU9250_ReadSelfTestAcc(uint8_t* self_test_acc);
+    void MPU9250_ReadSelfTestGyro(int16_t* self_test_gyro);
+    void MPU9250_ReadSelfTestAcc(int16_t* self_test_acc);
     
     /**
     * @brief Perform self test of accelerometer and gyroscope.


### PR DESCRIPTION
Bug fix for the `MPU9250_SelfTest()` function. The issue regards the helper functions `MPU9250_ReadSelfTestAcc()` and `MPU9250_ReadSelfTestGyro()`, reading `int16_t` values into an array of `uint8_t` values.

----

Additional bug fixed: the parameter of the function `MPU9250_ReadMag()` was of type `uint16_t` instead of `int16_t`. 